### PR TITLE
Update .gitignore to exclude response.json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ __pycache__/
 .ruff_cache/
 .envrc
 int__cloud_subscriptions_daily_unioned.png
-diagram.excalidraw.p
+diagram.excalidraw.png
 response.json

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ __pycache__/
 .ruff_cache/
 .envrc
 int__cloud_subscriptions_daily_unioned.png
-diagram.excalidraw.png
+diagram.excalidraw.p
+response.json


### PR DESCRIPTION
This PR updates the `.gitignore` file to exclude `response.json`, ensuring that these files are not tracked by Git. This helps maintain a cleaner repository by preventing unnecessary files from being included in version control.

If it is not typical for a response.json to be generated, please close the pull request.